### PR TITLE
feat: enable multi-arch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,10 +29,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
       - name: Build image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
+          platforms: linux/amd64, linux/arm64
           tags: "latest"
           containerfiles: Containerfile
           


### PR DESCRIPTION
We can simply use qemu for multi-arch builds here since the images are small.

The workflows do take 2 hours to run, though this shouldn't be a frequent occurrence, and a temporary measure until Image Builder team fix their pipelines.